### PR TITLE
Fix note selection on initial load

### DIFF
--- a/js/notes.js
+++ b/js/notes.js
@@ -54,7 +54,10 @@ onload = () => {
     if (lastNote) {
       if (lastNote.classList.contains("selected")) {
         lastNote.classList.remove("selected");
-        displayNotes.firstElementChild.classList.add("selected");
+        let firstElement = displayNotes.firstElementChild;
+        firstElement.classList.add("selected");
+        contentTitle.innerText = firstElement.querySelector('h3').textContent;
+        contentBody.innerText = firstElement.querySelector('p').textContent;
       }
     }
     noteSelect();


### PR DESCRIPTION
The first note is selected on load, but values are not populated in the right-side panel.
FIX: Populated the title and body in the right side panel.

Issue: [#2](https://github.com/swagatmitra-b/Productivity-App/issues/2)